### PR TITLE
Removed beginning and ending comment-outs

### DIFF
--- a/themes/default/public/styles/raneto.css
+++ b/themes/default/public/styles/raneto.css
@@ -1,4 +1,3 @@
-/*
 .header {
   color: #CCC;
   background: #b3ba3f;
@@ -505,4 +504,4 @@ input:focus::-ms-input-placeholder {
   .nl-form {
     font-size: 2em;
   }
-}*/
+}


### PR DESCRIPTION
Removes some comment tags that were placed at the beginning and at the end of the main CSS sheet.